### PR TITLE
Update README URLs based on HTTP redirects

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ This repository is a clone of [ipfs/community](https://github.com/ipfs/community
 
 ## Contribute
 
-Contributions welcome. Please check out [the issues](https://github.com/libp2p/community/issues).
+Contributions welcome. Please check out [the issues](https://github.com/libp2p/community/pulls).
 
 Check out our [contributing document](https://github.com/libp2p/community/blob/master/CONTRIBUTE.md) for more information on how we work, and about contributing in general.
 


### PR DESCRIPTION
Created with https://github.com/dkhamsing/frankenstein

### GitHub Corrected URLs 
Was | Now 
--- | --- 
https://github.com/libp2p/community/issues | https://github.com/libp2p/community/pulls 
