### PR TITLE
Add Code of Conduct (forked from IPFS)

### DIFF
--- a/CONTRIBUTE.md
+++ b/CONTRIBUTE.md
@@ -1,8 +1,9 @@
 # Contributing
 
-[![](https://img.shields.io/badge/made%20by-Protocol%20Labs-blue.svg?style=flat-square)](http://ipn.io)
-[![](https://img.shields.io/badge/project-libp2p-blue.svg?style=flat-square)](http://github.com/libp2p/libp2p)
-[![](https://img.shields.io/badge/freenode-%23ipfs-blue.svg?style=flat-square)](http://webchat.freenode.net/?channels=%23ipfs)
+[![](https://img.shields.io/badge/made%20by-Protocol%20Labs-blue.svg?style=flat-square)](https://protocol.ai)
+[![](https://img.shields.io/badge/project-libp2p-yellow.svg?style=flat-square)](http://github.com/libp2p/libp2p)
+[![](https://img.shields.io/badge/freenode-%23libp2p-yellow.svg?style=flat-square)](http://webchat.freenode.net/?channels=%23libp2p)
+[![Discourse posts](https://img.shields.io/discourse/https/discuss.libp2p.io/posts.svg)](https://discuss.libp2p.io)
 
 Want to hack on libp2p? Awesome! Here are instructions to get you started.
 They are not perfect yet. Please let us know what feels wrong or incomplete.
@@ -43,7 +44,7 @@ We want to keep the libp2p community awesome, growing and collaborative. We need
 
 - Stay on topic: Make sure that you are posting to the correct channel and avoid off-topic discussions. Remember when you update an issue or respond to an email you are potentially sending to a large number of people. Please consider this before you update. Also remember that nobody likes spam.
 
-There is also a more extensive [code of conduct](https://github.com/ipfs/community/blob/master/code-of-conduct.md) which we follow, which can be found as part of the related IPFS organisation.
+There is also a more extensive [code of conduct](https://github.com/libp2p/community/blob/master/code-of-conduct.md) which we follow, which can be found as part of the related IPFS organisation.
 
 ### Reporting Issues
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,9 @@
 # community
 
-[![](https://img.shields.io/badge/made%20by-Protocol%20Labs-blue.svg?style=flat-square)](http://ipn.io)
-[![](https://img.shields.io/badge/project-libp2p-blue.svg?style=flat-square)](http://github.com/libp2p/libp2p)
-[![](https://img.shields.io/badge/freenode-%23ipfs-blue.svg?style=flat-square)](http://webchat.freenode.net/?channels=%23ipfs)
+[![](https://img.shields.io/badge/made%20by-Protocol%20Labs-blue.svg?style=flat-square)](https://protocol.ai)
+[![](https://img.shields.io/badge/project-libp2p-yellow.svg?style=flat-square)](http://github.com/libp2p/libp2p)
+[![](https://img.shields.io/badge/freenode-%23libp2p-yellow.svg?style=flat-square)](http://webchat.freenode.net/?channels=%23libp2p)
+[![Discourse posts](https://img.shields.io/discourse/https/discuss.libp2p.io/posts.svg)](https://discuss.libp2p.io)
 
 > General discussion and documentation on community practices
 
@@ -14,4 +15,4 @@ Contributions welcome. Please check out [the issues](https://github.com/libp2p/c
 
 Check out our [contributing document](https://github.com/libp2p/community/blob/master/CONTRIBUTE.md) for more information on how we work, and about contributing in general.
 
-Please be aware that all interactions related to libp2p are subject to the IPFS [Code of Conduct](https://github.com/ipfs/community/blob/master/code-of-conduct.md).
+Please be aware that all interactions related to libp2p are subject to the libp2p [Code of Conduct](https://github.com/libp2p/community/blob/master/code-of-conduct.md).

--- a/code-of-conduct.md
+++ b/code-of-conduct.md
@@ -87,6 +87,12 @@ Conduct, please contact us at abuse@libp2p.io to send us an abuse report. If
 this is the initial report of a problem, please include as much detail as
 possible. It is easiest for us to address issues when we have more context.
 
+If you are at an event organized by the libp2p community, contact a _duty
+officer_ or event staff. To learn more about our procedures handling incidents
+and reports at events, read the [IPFS community procedures for in-person
+events](https://github.com/ipfs/community/code-of-conduct-procedures-for-events.md),
+which is adopted by both the libp2p and IPFS communities.
+
 ## Copyright Violations
 
 We respect the intellectual property of others and ask that you do too. If you

--- a/code-of-conduct.md
+++ b/code-of-conduct.md
@@ -1,0 +1,152 @@
+# libp2p Community Code of Conduct
+
+We believe that our mission is best served in an environment that is friendly,
+safe, and accepting; free from intimidation or harassment.
+
+Towards this end, certain behaviors and practices will not be tolerated.
+
+## tl;dr
+
+- Be respectful.
+- We're here to help: abuse@libp2p.io
+- Abusive behavior is never tolerated.
+- Violations of this code may result in swift and permanent expulsion from the libp2p community.
+- "Too long, didn't read" is not a valid excuse for not knowing what is in this document.
+
+## Table of Contents
+
+- [Scope](#scope)
+- [Friendly Harassment-Free Space](#friendly-harassment-free-space)
+- [Reporting Violations of this Code of Conduct](#reporting-violations-of-this-code-of-conduct)
+- [Copyright Violations](#copyright-violations)
+- [Consequences](#consequences)
+- [Addressing Grievances](#addressing-grievances)
+- [Contact Info](#contact-info)
+- [Changes](#changes)
+- [Credit and License](#credit-and-license)
+
+## Scope
+
+We expect all members of the libp2p community to abide by this Code of Conduct
+at all times in all libp2p community venues, online and in person, and in one-on-one
+communications pertaining to libp2p affairs.
+
+This policy covers the usage of libp2p public infrastructure, including public
+relay and bootstrapping nodes, as well as libp2p websites, libp2p related
+events, and any other services offered by or on behalf of the libp2p community.
+It also applies to behavior in the context of the libp2p Open Source project
+communities, including but not limited to public GitHub repositories, IRC
+channels, social media, mailing lists, and public events.
+
+This Code of Conduct is in addition to, and does not in any way nullify or
+invalidate, any other terms or conditions related to use of libp2p services.
+
+The definitions of various subjective terms such as "discriminatory", "hateful",
+or "confusing" will be decided at the sole discretion of the libp2p abuse team.
+
+## Friendly Harassment-Free Space
+
+We are committed to providing a friendly, safe and welcoming environment for
+all, regardless of gender identity, sexual orientation, disability, ethnicity,
+religion, age, physical appearance, body size, race, or similar personal
+characteristics.
+
+We ask that you please respect that people have differences of opinion
+regarding technical choices, and that every design or implementation choice
+carries a trade-off and numerous costs. There is seldom a single right answer.
+A difference of technology preferences is not a license to be rude.
+
+Any spamming, trolling, flaming, baiting, or other attention-stealing
+behavior is not welcome, and will not be tolerated.
+
+Harassing other users is never tolerated, whether via public or private media.
+
+Avoid using offensive or harassing nicknames, or other identifiers that might
+detract from a friendly, safe, and welcoming environment for all.
+
+Harassment includes, but is not limited to: harmful or prejudicial verbal or
+written comments related to gender identity, sexual orientation, disability,
+ethnicity, religion, age, physical appearance, body size, race, or similar
+personal characteristics; inappropriate use of nudity, sexual images, and/or
+sexually explicit language in public spaces; threats of physical or non-
+physical harm; deliberate intimidation, stalking or following; harassing
+photography or recording; sustained disruption of talks or other events;
+inappropriate physical contact; and unwelcome sexual attention.
+
+Media shared through public infrastructure run by the libp2p team must not
+contain illegal or infringing content. You should only publish content via
+libp2p public infrastructure if you have the right to do so. This includes
+complying with all software license agreements or other intellectual property
+restrictions. You will be solely responsible for any violation of laws or
+others’ intellectual property rights.
+
+## Reporting Violations of this Code of Conduct
+
+If you believe someone is harassing you or has otherwise violated this Code of
+Conduct, please contact us at abuse@libp2p.io to send us an abuse report. If
+this is the initial report of a problem, please include as much detail as
+possible. It is easiest for us to address issues when we have more context.
+
+## Copyright Violations
+
+We respect the intellectual property of others and ask that you do too. If you
+believe any content or other materials available through public libp2p
+infrastructure violates a copyright held by you and you would like to submit a
+notice pursuant to the Digital Millennium Copyright Act or other similar
+international law, you can submit a notice to our agent for service of notice
+to: abuse@libp2p.io
+
+(We will add a physical mailing address here when we acquire one).
+
+Please make sure your notice meets the Digital Millennium Copyright Act
+requirements.
+
+## Consequences
+
+All content published to public libp2p infrastructure is hosted at the sole
+discretion of the libp2p team.
+
+Unacceptable behavior from any community member will not be tolerated.
+
+Anyone asked to stop unacceptable behavior is expected to comply immediately.
+
+If a community member engages in unacceptable behavior, the libp2p team
+may take any action they deem appropriate, up to and including a temporary ban
+or permanent expulsion from the community without warning (and without refund
+in the case of a paid event or service).
+
+## Addressing Grievances
+
+If you feel you have been falsely or unfairly accused of violating this Code
+of Conduct, you should notify the libp2p team. We will do our best to ensure
+that your grievance is handled appropriately.
+
+In general, we will choose the course of action that we judge as being most in
+the interest of fostering a safe and friendly community.
+
+On IRC, let one of the ops know if you think that someone has transgressed
+against the Code of Conduct. If you would like to be an op and promise to
+help maintain and abide by the code, please let us know.
+
+## Contact Info
+
+Please contact abuse@libp2p.io if you need to report a problem or address a
+grievance related to an abuse report.
+
+You are also encouraged to contact us if you are curious about something that
+might be "on the line" between appropriate and inappropriate content. We are
+happy to provide guidance to help you be a successful part of our community.
+
+## Changes
+
+This is a living document and may be updated from time to time. Please refer
+to the git history for this document to view the changes.
+
+## Credit and License
+
+This Code of Conduct is based on the [IPFS Code of
+Conduct](https://github.com/ipfs/community/code-of-conduct.md), which in turn is
+based on the [npm Code of Conduct](https://www.npmjs.com/policies/conduct).
+
+This document may be reused under a [Creative Commons Attribution-ShareAlike
+License](http://creativecommons.org/licenses/by-sa/4.0/).


### PR DESCRIPTION
This pulls in the IPFS code of conduct with a bit of `s/IPFS/libp2p/g` magic :)

I didn't fork the [in-person event procedures doc](https://github.com/ipfs/community/blob/master/code-of-conduct-procedures-for-events.md), since there are some TODO notes in there, and it seemed simpler to just link to the IPFS doc than to try to keep a fork in sync with changes.

@raulk do you know if an `abuse@libp2p.io` email exists already? If not, we should create one.